### PR TITLE
chart: fix docs to make examples at least buildable

### DIFF
--- a/chart/Graphics/Rendering/Chart/Simple.hs
+++ b/chart/Graphics/Rendering/Chart/Simple.hs
@@ -21,9 +21,15 @@
 --
 -- Examples:
 --
--- > plotPDF "foo.pdf" [0,0.1..10] sin "- " cos ". " cos "o"
+-- > -- this plotters
+-- > import Graphics.Rendering.Chart.Simple
+-- > -- rendering instances from 'chart-cairo' package
+-- > import Graphics.Rendering.Chart.Backend.Cairo
 --
--- > plotPS "foo.ps" [0,0.1..10] (sin . exp) "- " (sin . exp) "o-"
+-- > main = do
+-- >     plotPDF "foo.pdf" [0 :: Double, 0.1..10] sin "- " cos ". " cos "o"
+--
+-- >     plotPS "foo.ps" [0 :: Double, 0.1..10] (sin . exp) "- " (sin . exp) "o-"
 -----------------------------------------------------------------------------
 module Graphics.Rendering.Chart.Simple( plot, PlotKind(..), xcoords,
                                         plotPDF, plotPS,


### PR DESCRIPTION
Without importing orphan instances error messages
hardly make sense for newcomer:

> chart.hs:9:5:
>     No instance for (Graphics.Rendering.Chart.Simple.Internal.IsPlot
>                        t0)
>       arising from a use of `plotPS'
>     The type variable`t0' is ambiguous
>     Possible fix: add a type signature that fixes these type variable(s)
>     Note: there are several potential instances:
>       instance (Graphics.Rendering.Chart.Simple.Internal.IsPlot p,
>                 Graphics.Rendering.Chart.Simple.Internal.IsPlot q) =>
>                Graphics.Rendering.Chart.Simple.Internal.IsPlot (p, q)
>         -- Defined in `Graphics.Rendering.Chart.Simple.Internal'
>       instance (Graphics.Rendering.Chart.Simple.Internal.IsPlot p,
>                 Graphics.Rendering.Chart.Simple.Internal.IsPlot q,
>                 Graphics.Rendering.Chart.Simple.Internal.IsPlot r) =>
>                Graphics.Rendering.Chart.Simple.Internal.IsPlot (p, q, r)
>         -- Defined in`Graphics.Rendering.Chart.Simple.Internal'
>       instance (Real a, Real b, Fractional a, Fractional b) =>
>                Graphics.Rendering.Chart.Simple.Internal.IsPlot (a -> b)
>         -- Defined in `Graphics.Rendering.Chart.Simple.Internal'
>       ...plus four others
>     In a stmt of a 'do' block:
>       plotPS "foo.ps" [0, 0.1 .. 10] (sin . exp) "- " (sin . exp) "o-"
>     In the expression:
>       do { plotPNG "foo.png" ds sin "- " cos ". " cos "o";
>            plotPS "foo.ps" [0, 0.1 .. 10] (sin . exp) "- " (sin . exp) "o-" }
>     In an equation for`main':
>         main
>           = do { plotPNG "foo.png" ds sin "- " cos ". " cos "o";
>                  plotPS "foo.ps" [0, 0.1 .. 10](sin . exp) "- " (sin . exp) "o-" }

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
