### PR TITLE
BUGFIX: textDrawRect

### DIFF
--- a/chart-tests/tests/Test8.hs
+++ b/chart-tests/tests/Test8.hs
@@ -15,6 +15,7 @@ chart = mapPickFn (const ()) $ pieToRenderable layout
     layout = pie_title .~ "Pie Chart Example"
            $ pie_plot . pie_data .~ [ def{_pitem_value=v,_pitem_label=s,_pitem_offset=o}
                                       | (s,v,o) <- values ]
+           $ pie_plot . pie_label_style .~ (font_size .~ 20 $ def)
            $ def
 
 -- main = main' "test8" chart


### PR DESCRIPTION
The bounding-box calculation had the Y axis reversed, so the box was below the label. I have left in a commented-out version of drawTextA which adds in the bounding box, since there are differences between PNG/Cairo and SVG/Diagrams output, e.g. test8, which looks like a SVG rendering issue but I have not looked into it too deeply (you also see this difference in the misc1\* tests).
