### PR TITLE
gtk >= 0.13 compatability

### DIFF
--- a/chart-gtk/Chart-gtk.cabal
+++ b/chart-gtk/Chart-gtk.cabal
@@ -19,7 +19,8 @@ library
                , cairo >= 0.9.11
                , colour >= 2.2.1 && < 2.4
                , colour >= 2.2.1
-               , gtk >= 0.9.11 && < 0.13
+               , gtk >= 0.13
+               , text
                , Chart >= 1.2 && < 1.3
                , Chart-cairo >= 1.2 && < 1.3
 

--- a/chart-gtk/Graphics/Rendering/Chart/Gtk.hs
+++ b/chart-gtk/Graphics/Rendering/Chart/Gtk.hs
@@ -20,15 +20,17 @@ import Graphics.Rendering.Chart.Drawing
 import Graphics.Rendering.Chart.Backend.Cairo
 import Data.List (isPrefixOf)
 import Data.IORef
+import qualified Data.Text as T
 import Control.Monad(when)
 import System.IO.Unsafe(unsafePerformIO)
 
 -- do action m for any keypress (except meta keys)
 anyKey :: (Monad m) => m a -> GE.Event -> m Bool
 anyKey m (GE.Key {GE.eventKeyName=key})
-    | any (`isPrefixOf` key) ignores = return True
-    | otherwise                      = m >> return True
-  where ignores = ["Shift","Control","Alt",
+    | any (`T.isPrefixOf` key) ignores = return True
+    | otherwise                        = m >> return True
+  where ignores = map T.pack
+                  ["Shift","Control","Alt",
                    "Super","Meta","Hyper"]
 
 -- Yuck. But we really want the convenience function


### PR DESCRIPTION
the first commit sets a bound `gtk < 0.13`, the second commit changes the bound to `>= 0.13` and fixes the incompatability, see #41
