### PR TITLE
Add Vector Plots

### DIFF
--- a/chart-tests/tests/Tests.hs
+++ b/chart-tests/tests/Tests.hs
@@ -360,6 +360,29 @@ test13 lw = fillBackground fwhite $ (gridToRenderable t)
 
 
 ----------------------------------------------------------------------
+-- Vector Plot Test
+
+test18 :: Renderable (LayoutPick Double Double Double)
+test18 = layoutToRenderable layout
+  where
+    grid = [(x,y) | x <- range, y <- range] where range = [-5,-4..5]
+
+    proj1 = plot_vectors_style . vector_head_style . point_color .~ (opaque green)
+          $ plot_vectors_mapf .~ (\(x,y) -> (-x,-y))
+          $ plot_vectors_grid .~ grid
+          $ plot_vectors_title .~ "Projection1"
+          $ def
+
+    proj2 = plot_vectors_mapf .~ (\(x,y) -> (-(x+1), -(y-1)))
+          $ plot_vectors_grid .~ grid
+          $ plot_vectors_title .~ "Projection2"
+          $ def
+
+    layout = layout_title .~ "Vector Plot: Abyss"
+           $ layout_plots .~ plotVectorField `liftM` [proj1,proj2]
+           $ def
+
+----------------------------------------------------------------------
 -- a quick test to display labels with all combinations
 -- of anchors
 misc1 fsz rot lw = fillBackground fwhite $ (gridToRenderable t)
@@ -440,6 +463,7 @@ allTests =
      , ("test15a", stdSize, const $ simple (Test15.chart (LORows 2)))
      , ("test15b", stdSize, const $ simple (Test15.chart (LOCols 2)))
      , ("test17", stdSize,  \lw -> simple $ Test17.chart lw)
+     , ("test18", stdSize, const $ simple test18)
      , ("misc1",  stdSize, setPickFn nullPickFn . misc1 20 0)
        -- perhaps a bit excessive
      , ("misc1a", stdSize, setPickFn nullPickFn . misc1 12 45)

--- a/chart/Chart.cabal
+++ b/chart/Chart.cabal
@@ -52,6 +52,7 @@ library
         Graphics.Rendering.Chart.Plot.FillBetween,
         Graphics.Rendering.Chart.Plot.Hidden,
         Graphics.Rendering.Chart.Plot.Lines,
+        Graphics.Rendering.Chart.Plot.Vectors,
         Graphics.Rendering.Chart.Plot.Pie,
         Graphics.Rendering.Chart.Plot.Points
         Graphics.Rendering.Chart.SparkLine

--- a/chart/Graphics/Rendering/Chart/Drawing.hs
+++ b/chart/Graphics/Rendering/Chart/Drawing.hs
@@ -70,6 +70,7 @@ module Graphics.Rendering.Chart.Drawing
   , plusses
   , exes
   , stars
+  , arrows
     
   , solidFillStyle
   
@@ -331,6 +332,7 @@ data PointShape = PointShapeCircle           -- ^ A circle.
                 | PointShapePlus  -- ^ A plus sign.
                 | PointShapeCross -- ^ A cross.
                 | PointShapeStar  -- ^ Combination of a cross and a plus.
+                | PointShapeArrowHead Double
 
 -- | Abstract data type for the style of a plotted point.
 data PointStyle = PointStyle
@@ -365,7 +367,7 @@ defaultPointStyle = def
 drawPoint :: PointStyle  -- ^ Style to use when rendering the point.
           -> Point       -- ^ Position of the point to render.
           -> ChartBackend ()
-drawPoint ps@(PointStyle _ _ _ r shape) p = withPointStyle ps $ do
+drawPoint ps@(PointStyle cl _ _ r shape) p = withPointStyle ps $ do
   p'@(Point x y) <- alignStrokePoint p
   case shape of
     PointShapeCircle -> do
@@ -383,6 +385,9 @@ drawPoint ps@(PointStyle _ _ _ r shape) p = withPointStyle ps $ do
       let path = G.moveTo p1 <> mconcat (map lineTo p1s) <> lineTo p1
       fillPath path
       strokePath path
+    PointShapeArrowHead theta ->
+      withTranslation p $ withRotation (theta - pi/2) $
+          drawPoint (filledPolygon r 3 True cl) (Point 0 0)
     PointShapePlus -> 
       strokePath $ moveTo' (x+r) y
                 <> lineTo' (x-r) y
@@ -484,6 +489,14 @@ stars :: Double -- ^ Radius of circle.
       -> PointStyle
 stars radius w cl =
   PointStyle transparent cl w radius PointShapeStar
+
+arrows :: Double -- ^ Radius of circle.
+       -> Double -- ^ Rotation (Tau)
+       -> Double -- ^ Thickness of line.
+       -> AlphaColour Double -- ^ Color of line.
+       -> PointStyle
+arrows radius angle w cl =
+  PointStyle transparent cl w radius (PointShapeArrowHead angle)
 
 -- | Fill style that fill everything this the given colour.
 solidFillStyle :: AlphaColour Double -> FillStyle

--- a/chart/Graphics/Rendering/Chart/Geometry.hs
+++ b/chart/Graphics/Rendering/Chart/Geometry.hs
@@ -20,6 +20,8 @@ module Graphics.Rendering.Chart.Geometry
   , pvadd
   , pvsub
   , psub
+  , vangle
+  , vlen
   , vscale
   , within
   , intersectRect
@@ -49,7 +51,13 @@ module Graphics.Rendering.Chart.Geometry
   , invert
   ) where
 
+import qualified Prelude
+import Prelude hiding ((^))
 import Data.Monoid
+
+-- The homomorphic version to avoid casts inside the code.
+(^) :: Num a => a -> Integer -> a
+(^) = (Prelude.^)
 
 -- | A point in two dimensions.
 data Point = Point {
@@ -66,6 +74,17 @@ data Vector = Vector {
 -- | Convert a 'Point' to a 'Vector'.
 pointToVec :: Point -> Vector
 pointToVec (Point x y) = Vector x y
+
+-- | Angle of a vector (counterclockwise from positive x-axis)
+vangle :: Vector -> Double
+vangle (Vector x y)
+    | x > 0 = atan (y/x)
+    | x < 0 = atan (y/x) + pi
+    | otherwise = if y > 0 then pi/2 else -pi/2
+
+-- | Length/magnitude of a vector
+vlen :: Vector -> Double
+vlen (Vector x y) = sqrt $ x^2 + y^2
 
 -- | Scale a vector by a constant.
 vscale :: Double -> Vector -> Vector

--- a/chart/Graphics/Rendering/Chart/Plot.hs
+++ b/chart/Graphics/Rendering/Chart/Plot.hs
@@ -10,6 +10,7 @@
 module Graphics.Rendering.Chart.Plot(
     module Graphics.Rendering.Chart.Plot.Types,
     module Graphics.Rendering.Chart.Plot.Lines,
+    module Graphics.Rendering.Chart.Plot.Vectors,
     module Graphics.Rendering.Chart.Plot.Points,
     module Graphics.Rendering.Chart.Plot.FillBetween,
     module Graphics.Rendering.Chart.Plot.ErrBars,
@@ -23,6 +24,7 @@ module Graphics.Rendering.Chart.Plot(
 
 import Graphics.Rendering.Chart.Plot.Types
 import Graphics.Rendering.Chart.Plot.Lines
+import Graphics.Rendering.Chart.Plot.Vectors
 import Graphics.Rendering.Chart.Plot.Points
 import Graphics.Rendering.Chart.Plot.FillBetween
 import Graphics.Rendering.Chart.Plot.ErrBars

--- a/chart/Graphics/Rendering/Chart/Plot/Vectors.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/Vectors.hs
@@ -1,0 +1,142 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Graphics.Rendering.Chart.Plot.Vectors
+-- Copyright   :  (c) Anton Vorontsov <anton@enomsg.org> 2014
+-- License     :  BSD-style (see chart/COPYRIGHT)
+--
+-- Vector plots
+--
+{-# LANGUAGE TemplateHaskell #-}
+
+module Graphics.Rendering.Chart.Plot.Vectors(
+    PlotVectors(..),
+    VectorStyle(..),
+    plotVectorField,
+    plot_vectors_mapf,
+    plot_vectors_grid,
+    plot_vectors_title,
+    plot_vectors_style,
+    plot_vectors_scale,
+    plot_vectors_values,
+    vector_line_style,
+    vector_head_style,
+) where
+
+import Control.Lens
+import Control.Monad
+import Control.Applicative
+import Data.Tuple
+import Data.Colour hiding (over)
+import Data.Colour.Names
+import Data.Default.Class
+import Graphics.Rendering.Chart.Axis
+import Graphics.Rendering.Chart.Drawing
+import Graphics.Rendering.Chart.Geometry
+import Graphics.Rendering.Chart.Plot.Types
+
+data VectorStyle = VectorStyle
+    { _vector_line_style :: LineStyle
+    , _vector_head_style :: PointStyle
+    }
+
+$( makeLenses ''VectorStyle )
+
+data PlotVectors x y = PlotVectors
+    { _plot_vectors_title        :: String
+    , _plot_vectors_style        :: VectorStyle
+    -- | Set to 1 (default) to normalize the length of vectors to a space
+    --   between them (so that the vectors never overlap on the graph).
+    --   Set to 0 to disable any scaling.
+    --   Values in between 0 and 1 are also permitted to adjust scaling.
+    , _plot_vectors_scale        :: Double
+    -- | Provide a square-tiled regular grid.
+    , _plot_vectors_grid         :: [(x,y)]
+    -- | Provide a vector field (R^2 -> R^2) function.
+    , _plot_vectors_mapf         :: (x,y) -> (x,y)
+    -- | Provide a prepared list of (start,vector) pairs.
+    , _plot_vectors_values       :: [((x,y),(x,y))]
+    }
+
+$( makeLenses ''PlotVectors )
+
+mapGrid :: (PlotValue y, PlotValue x)
+        => [(x,y)] -> ((x,y) -> (x,y)) -> [((x,y),(x,y))]
+mapGrid grid f = zip grid (f <$> grid)
+
+plotVectorField :: (PlotValue x, PlotValue y) => PlotVectors x y -> Plot x y
+plotVectorField pv = Plot
+    { _plot_render     = renderPlotVectors pv
+    , _plot_legend     = [(_plot_vectors_title pv, renderPlotLegendVectors pv)]
+    , _plot_all_points = (map fst pts, map snd pts)
+    }
+  where
+    pvals = _plot_vectors_values pv
+    mvals = mapGrid (_plot_vectors_grid pv) (_plot_vectors_mapf pv)
+    pts = concatMap (\(a,b) -> [a,b]) (pvals ++ mvals)
+
+renderPlotVectors :: (PlotValue x, PlotValue y)
+                  => PlotVectors x y -> PointMapFn x y -> ChartBackend ()
+renderPlotVectors pv pmap = do
+    let pvals   = _plot_vectors_values pv
+        mvals   = mapGrid (_plot_vectors_grid pv) (_plot_vectors_mapf pv)
+        trans   = translateToStart <$> (pvals ++ mvals)
+        pvecs   = filter (\v -> vlen' v > 0) $ over both (mapXY pmap) <$> trans
+        mgrid   = take 2 $ fst <$> pvecs
+        maxLen  = maximum $ vlen' <$> pvecs
+        spacing = (!!1) $ (vlen <$> zipWith psub mgrid (reverse mgrid)) ++ [maxLen]
+        sfactor = spacing/maxLen                  -- Non-adjusted scale factor
+        afactor = sfactor + (1 - sfactor)*(1 - _plot_vectors_scale pv)
+        tails   = pscale afactor <$> pvecs          -- Paths of arrows' tails
+        angles  = (vangle . psub' . swap) <$> pvecs -- Angles of the arrows
+        centers = snd <$> tails                     -- Where to draw arrow heads
+    mapM_ (drawTail radius) tails
+    zipWithM_ (drawArrowHead radius) centers angles
+  where
+    psub' = uncurry psub
+    vlen' = vlen . psub'
+    pvs = _plot_vectors_style pv
+    radius = _point_radius $ _vector_head_style pvs
+    hs angle = _vector_head_style pvs & point_shape
+                  %~ (\(PointShapeArrowHead a) -> PointShapeArrowHead $ a+angle)
+    translateToStart (s@(x,y),(vx,vy)) = (s,(tr x vx,tr y vy))
+      where tr p t = fromValue $ toValue p + toValue t
+    pscale w v@(s,_) = (s,translateP (vscale w . psub' $ swap v) s)
+    drawTail r v = withLineStyle (_vector_line_style pvs) $
+        strokePointPath $ (^..each) v'
+      where
+        v'  = pscale (1-(3/2)*r/l) v
+        l   = vlen' v
+    drawArrowHead r (Point x y) theta =
+        withTranslation (Point (-r*cos theta) (-r*sin theta))
+                        (drawPoint (hs theta) (Point x y))
+
+renderPlotLegendVectors :: (PlotValue x, PlotValue y)
+                        => PlotVectors x y -> Rect -> ChartBackend ()
+renderPlotLegendVectors pv (Rect p1 p2) = do
+    let y = (p_y p1 + p_y p2)/2
+        pv' = plot_vectors_grid .~ []
+            $ plot_vectors_values .~ [((fromValue $ p_x p1, fromValue y),
+                                       (fromValue $ p_x p2, fromValue 0))]
+            $ pv
+    renderPlotVectors pv' pmap
+  where
+    pmap (LValue x,LValue y) = Point (toValue x) (toValue y)
+    pmap _ = Point 0 0
+
+instance Default VectorStyle where
+  def = VectorStyle
+    { _vector_line_style = (solidLine lw $ opaque blue)
+                              { _line_cap = LineCapSquare }
+    , _vector_head_style = PointStyle (opaque red) transparent lw (2*lw)
+                                      (PointShapeArrowHead 0)
+    } where lw = 2
+
+instance Default (PlotVectors x y) where
+  def = PlotVectors
+    { _plot_vectors_title        = ""
+    , _plot_vectors_style        = def
+    , _plot_vectors_scale        = 1
+    , _plot_vectors_grid         = []
+    , _plot_vectors_mapf         = id
+    , _plot_vectors_values       = []
+    }

--- a/wiki-examples/example12.hs
+++ b/wiki-examples/example12.hs
@@ -1,0 +1,39 @@
+import Graphics.Rendering.Chart
+import Graphics.Rendering.Chart.Backend.Cairo
+import Control.Lens
+import Control.Applicative
+import Data.Colour
+import Data.Colour.Names
+import Data.Default.Class
+import qualified Prelude
+import Prelude hiding ((^))
+
+(^) :: Num a => a -> Integer -> a
+(^) = (Prelude.^)
+
+chart :: Renderable ()
+chart = toRenderable layout
+  where
+    add (x1,y1) (x2,y2) = (x1+x2,y1+y2)
+    square a s = [(x,y) | x <- range, y <- range]
+      where range = [-a,-a+s..a] :: [Double]
+    r' x y z = sqrt $ x^2 + y^2 + z^2
+    efield sign x y = ( sign*x/r,sign*y/r) where r = r' x y 10
+    bfield sign x y = (-sign*y/r^2,sign*x/r^2) where r = r' x y 10
+    eplot = plot_vectors_mapf .~ (\(x,y) ->
+                efield 1 (x-20) y `add` efield (-1) (x+20) y)
+          $ plot_vectors_grid  .~ square 30 3
+          $ plot_vectors_style . vector_line_style . line_color .~ opaque gray
+          $ plot_vectors_style . vector_head_style . point_color .~ opaque black
+          $ plot_vectors_title .~ "Electric field"
+          $ def
+    bplot = plot_vectors_mapf .~ (\(x,y) ->
+                bfield 1 (x-20) y `add` bfield (-1) (x+20) y)
+          $ plot_vectors_grid  .~ square 30 5
+          $ plot_vectors_title .~ "B-field"
+          $ def
+    layout = layout_title .~ "Positive and Negative Charges"
+           $ layout_plots .~ (plotVectorField <$> [eplot,bplot])
+           $ def
+
+main = renderableToFile def chart "example12_big.png"


### PR DESCRIPTION
![from_diagrams](https://cloud.githubusercontent.com/assets/2905226/4021844/6863b766-2b0a-11e4-8622-d95f2aec4e84.png)

Hello,

The patch adds support for Vector Plots.
- The vectors can be plotted via a combination of a vector-field function
  and a grid, or by providing a list of pre-computed values.
- Heads and tails' styles are configurable. As for shapes, for now the
  only option for heads is a triangle, implemented via a polygon. Backends
  may provide more shapes, e.g. Diagrams have fancy ones.
- The support might be a good foundation for Stream Plots as well.

Thanks!
Anton
