### PR TITLE
Add ToRenderable instance for StackedLayouts type

### DIFF
--- a/chart/Graphics/Rendering/Chart/Layout.hs
+++ b/chart/Graphics/Rendering/Chart/Layout.hs
@@ -492,6 +492,12 @@ data StackedLayouts x = StackedLayouts
 instance Default (StackedLayouts x) where
   def = StackedLayouts [] True
 
+
+
+instance Ord x => ToRenderable (StackedLayouts x) where
+  toRenderable = renderStackedLayouts
+
+
 -- | Render several layouts with the same x-axis type and range,
 --   vertically stacked so that their origins and x-values are aligned.
 --


### PR DESCRIPTION
This instance seems to be missing.
