### PR TITLE
fixed examples to make them work with renamed functions

### DIFF
--- a/wiki-examples/example1.hs
+++ b/wiki-examples/example1.hs
@@ -28,5 +28,5 @@ chart = toRenderable layout
                               toPlot sinusoid2]
            $ def
 
-main = renderableToFile def "example1_big.png" chart
+main = renderableToFile def chart "example1_big.png"
 

--- a/wiki-examples/example10.hs
+++ b/wiki-examples/example10.hs
@@ -23,4 +23,4 @@ chart = toRenderable layout
            $ layout_plots .~ [toPlot bars, toPlot points]
            $ def
 
-main = renderableToFile def "example10_big.png" chart
+main = renderableToFile def chart "example10_big.png"

--- a/wiki-examples/example11.hs
+++ b/wiki-examples/example11.hs
@@ -30,4 +30,4 @@ chart borders = toRenderable layout
   bstyle = if borders then Just (solidLine 1.0 $ opaque black) else Nothing
   mkstyle c = (solidFillStyle c, bstyle)
 
-main = renderableToFile def "example11_big.png" (chart True)
+main = renderableToFile def (chart True) "example11_big.png"

--- a/wiki-examples/example2.hs
+++ b/wiki-examples/example2.hs
@@ -34,4 +34,4 @@ chart = toRenderable layout
            $ layoutlr_grid_last .~ False
            $ def
 
-main = renderableToFile def "example2_big.png" chart
+main = renderableToFile def chart "example2_big.png"

--- a/wiki-examples/example3.hs
+++ b/wiki-examples/example3.hs
@@ -32,4 +32,4 @@ chart = toRenderable layout
            $ def
 
 
-main = renderableToFile def "example3_big.png" chart
+main = renderableToFile def chart "example3_big.png"

--- a/wiki-examples/example4.hs
+++ b/wiki-examples/example4.hs
@@ -38,4 +38,4 @@ chart lwidth = toRenderable (layout 1001 (trial bits) :: Layout Double LogValue)
     s1 = solidLine lwidth $ opaque green
     s2 = solidLine lwidth $ opaque blue
 
-main = renderableToFile def "example4_big.png" (chart 0.25)
+main = renderableToFile def (chart 0.25) "example4_big.png" 

--- a/wiki-examples/example5.hs
+++ b/wiki-examples/example5.hs
@@ -18,4 +18,4 @@ chart = toRenderable layout
            $ pie_plot . pie_data .~ map pitem values
            $ def
 
-main = renderableToFile def "example5_big.png" chart
+main = renderableToFile def chart "example5_big.png"

--- a/wiki-examples/example7.hs
+++ b/wiki-examples/example7.hs
@@ -21,4 +21,4 @@ chart = toRenderable layout
            $ layout_plots .~ [toPlot circleP]
            $ def
 
-main = renderableToFile def "example7_big.png" chart
+main = renderableToFile def chart "example7_big.png"

--- a/wiki-examples/example8.hs
+++ b/wiki-examples/example8.hs
@@ -17,7 +17,7 @@ chart lwidth = toRenderable layout
            $ layout_background .~ solidFillStyle (opaque white)
            $ layout_left_axis_visibility . axis_show_ticks .~ False
            $ layout_plots .~ [ toPlot price1, toPlot spots ]
-           $ layout_foreground .~ (opaque black)
+           $ setLayoutForeground (opaque black)
            $ def
 
     price1 = plot_lines_style .~ lineStyle
@@ -40,4 +40,4 @@ chart lwidth = toRenderable layout
               $ line_color .~ opaque blue
               $ def
 
-main = renderableToFile def "example8_big.png" (chart 0.25) 
+main = renderableToFile def (chart 0.25) "example8_big.png"

--- a/wiki-examples/example9.hs
+++ b/wiki-examples/example9.hs
@@ -22,7 +22,7 @@ chart = toRenderable layout
                               , Left  (toPlot aaplArea)
                               , Left  (toPlot aaplLine)
                               , Left  (toPlot aaplCandle) ]
-           $ layoutlr_foreground .~ (opaque black)
+           $ setLayoutLRForeground (opaque black)
            $ def
 
     aaplLine = plot_lines_style  .~ lineStyle 2 green
@@ -75,4 +75,4 @@ chart = toRenderable layout
                        $ line_color .~ opaque colour
                        $ def
 
-main = renderableToFile def "example9_big.png" chart
+main = renderableToFile def chart "example9_big.png"


### PR DESCRIPTION
Hi haskell-chart team!

The examples would not compile for me, and ghc noted that the error was at the call to `renderableToFile`.  It complained of a type error.

Re-ordering the function arguments fixed the issure, and now every example compiles and runs as expected for me.

Some other misc. fixes were necessary, mostly renaming deprecated functions within the body.

I hope this helps!
