### PR TITLE
Added PlotValue Float instance

### DIFF
--- a/chart/Graphics/Rendering/Chart/Axis/Floating.hs
+++ b/chart/Graphics/Rendering/Chart/Axis/Floating.hs
@@ -46,6 +46,11 @@ instance PlotValue Double where
     fromValue= id
     autoAxis = autoScaledAxis def
 
+instance PlotValue Float where
+    toValue  = realToFrac
+    fromValue= realToFrac
+    autoAxis = autoScaledAxis def
+
 -- | A wrapper class for doubles used to indicate they are to
 -- be plotted against a percentage axis.
 newtype Percent = Percent {unPercent :: Double}


### PR DESCRIPTION
I was surprised when I couldn't plot up an array of Float values, so I added this. Is there a reason not to include this instance (as it seems an obvious one)?