### PR TITLE
bump lens upper bound to < 4.13. see fpco/stackage#686

### DIFF
--- a/chart-cairo/Chart-cairo.cabal
+++ b/chart-cairo/Chart-cairo.cabal
@@ -20,7 +20,7 @@ library
                , colour >= 2.2.1 && < 2.4
                , data-default-class < 0.1
                , operational >= 0.2.2 && < 0.3
-               , lens >= 3.9 && < 4.12
+               , lens >= 3.9 && < 4.13
                , Chart >= 1.5 && < 1.6
 
   Exposed-modules:

--- a/chart/Chart.cabal
+++ b/chart/Chart.cabal
@@ -19,7 +19,7 @@ library
   Build-depends: base >= 3 && < 5
                , old-locale
                , time, mtl, array
-               , lens >= 3.9 && < 4.12
+               , lens >= 3.9 && < 4.13
                , colour >= 2.2.1 && < 2.4
                , data-default-class < 0.1
                , mtl >= 2.0 && < 2.3


### PR DESCRIPTION
Here's the `stack.yaml` file I used to test this change:

```
flags: {}
packages:
- chart/
- chart-cairo/
extra-deps:
- lens-4.12.2
- reflection-2
resolver: nightly-2015-07-24
```

In other words, I verified that Chart and Chart-cairo built successfully against lens-4.12.2.