### PR TITLE
Raise lucid-svg version upper bound to < 0.7

### DIFF
--- a/chart-diagrams/Chart-diagrams.cabal
+++ b/chart-diagrams/Chart-diagrams.cabal
@@ -35,7 +35,7 @@ library
                , SVGFonts >= 1.4 && < 1.6
                , colour >= 2.2.1 && < 2.4
                , blaze-markup >= 0.7 && < 0.8
-               , lucid-svg >= 0.4 && < 0.6
+               , lucid-svg >= 0.4 && < 0.7
                , bytestring >= 0.9 && < 1.0
                , operational >= 0.2.2 && < 0.3
                , containers >= 0.4 && < 0.6


### PR DESCRIPTION
I build this using lucid-svg-0.6.0.1, and it compiled. So I'm assuming there weren't any breaking changes in 0.6. 

Do you have tests that I can run to ensure that nothing broke?