### PR TITLE
scientific notation for labels

### DIFF
--- a/Doctests.hs
+++ b/Doctests.hs
@@ -1,0 +1,12 @@
+{-# OPTIONS_GHC -Wall #-}
+
+module Main ( main ) where
+
+import Test.DocTest
+
+main :: IO ()
+main =
+  doctest
+    [ "-ichart"
+    , "chart/Graphics/Rendering/Chart/Axis/Floating.hs"
+    ]

--- a/chart-tests/Chart-tests.cabal
+++ b/chart-tests/Chart-tests.cabal
@@ -47,3 +47,11 @@ Executable chart-harness
   Hs-Source-Dirs: tests
   Ghc-Options: -threaded
   default-language:    Haskell2010
+
+test-suite doctests
+  type:                exitcode-stdio-1.0
+  main-is:             Doctests.hs
+  build-depends:       base >= 4.7 && < 5
+                     , doctest >= 0.8
+  default-language:    Haskell2010
+  Hs-Source-Dirs:      tests

--- a/chart-tests/tests/Doctests.hs
+++ b/chart-tests/tests/Doctests.hs
@@ -7,6 +7,5 @@ import Test.DocTest
 main :: IO ()
 main =
   doctest
-    [ "-ichart"
-    , "chart/Graphics/Rendering/Chart/Axis/Floating.hs"
+    [ "../chart/Graphics/Rendering/Chart/Axis/Floating.hs"
     ]

--- a/chart/Graphics/Rendering/Chart/Axis/Floating.hs
+++ b/chart/Graphics/Rendering/Chart/Axis/Floating.hs
@@ -89,14 +89,14 @@ instance PlotValue LogValue where
 -- >>> showDs [0, 1, 2 :: Double]
 -- ["0","1","2"]
 --
--- >>> showDs [0, 1000, 2000 :: Double]
--- ["0.0e0","1.0e3","2.0e3"]
+-- >>> showDs [0, 1000000, 2000000 :: Double]
+-- ["0.0e0","1.0e6","2.0e6"]
 --
 -- >>> showDs [0, 0.001, 0.002 :: Double]
 -- ["0","0.001","0.002"]
 --
--- >>> showDs [-10000, -1000, 9000 :: Double]
--- ["-1.0e4","-1.0e3","9.0e3"]
+-- >>> showDs [-10000000, -1000000, 9000000 :: Double]
+-- ["-1.0e7","-1.0e6","9.0e6"]
 --
 -- >>> showDs [10, 11, 12 :: Double]
 -- ["10","11","12"]
@@ -104,14 +104,19 @@ instance PlotValue LogValue where
 -- >>> showDs [100, 101, 102 :: Double]
 -- ["100","101","102"]
 --
--- >>> showDs [1000, 1001, 1002 :: Double]
--- ["1000","1001","1002"]
+-- >>> showDs [100000, 100001, 100002 :: Double]
+-- ["100000","100001","100002"]
 --
--- >>> showDs [10000, 10001, 10002 :: Double]
--- ["1.0e4 + 0","1.0e4 + 1","1.0e4 + 2"]
+-- >>> showDs [1000000, 1000001, 1000002 :: Double]
+-- ["1.0e6 + 0","1.0e6 + 1","1.0e6 + 2"]
 --
--- >>> showDs [-10000, -10001, -10002 :: Double]
--- ["-1.0e4 + 2","-1.0e4 + 1","-1.0e4 + 0"]
+-- >>> showDs [10000000, 10000001, 10000002 :: Double]
+-- ["1.0e7 + 0","1.0e7 + 1","1.0e7 + 2"]
+--
+-- >>> showDs [-10000000, -10000001, -10000002 :: Double]
+-- ["-1.0e7 + 2","-1.0e7 + 1","-1.0e7 + 0"]
+--
+-- prop> let [s0, s1] = showDs [x, x + 1.0 :: Double] in s0 /= s1
 showDs :: forall d . (RealFloat d) => [d] -> [String]
 showDs xs
   | useOffset = map addShownOffset $ showWithoutOffset (map (\x -> x - offset) xs)
@@ -123,7 +128,7 @@ showDs xs
       -- if some data is positive and some negative, we don't need an offset
       | min' <= 0 && max' >= 0 = False
       -- if the range is significantly smaller than the average, we need an offset
-      | 1000 * abs (max' - min') < abs mean' = True
+      | 1e6 * abs (max' - min') < abs mean' = True
       | otherwise = False
 
     mean' :: d
@@ -152,7 +157,7 @@ showWithoutOffset xs
   | otherwise = map showD xs
   where
     -- use scientific notation if max value is too big or too small
-    useScientificNotation = maxAbs > 1100 || maxAbs < 0.001
+    useScientificNotation = maxAbs >= 1e6 || maxAbs <= 1e-6
     maxAbs = maximum (map abs xs)
 
 

--- a/chart/Graphics/Rendering/Chart/Axis/Int.hs
+++ b/chart/Graphics/Rendering/Chart/Axis/Int.hs
@@ -29,7 +29,7 @@ instance PlotValue Integer where
 
 defaultIntAxis :: (Show a) => LinearAxisParams a
 defaultIntAxis  = LinearAxisParams {
-    _la_labelf  = show,
+    _la_labelf  = map show,
     _la_nLabels = 5,
     _la_nTicks  = 10
 }


### PR DESCRIPTION
Switch to scientific notation for large or small labels
First pass at fixing #121.

This will use scientific notation for all or none of the labels,
because I think it looks better that way. It also will apply an offset
too all the labels if the dynamic range is too small compared to the mean.

I included doctests which are run with

    > runghc Doctests.hs

from the top-level git directory. If there is an unsatisfactory result from this
new function, a new doctest should be added.