### PR TITLE
Add data point labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ chart-simple/dist/
 chart-tests/dist/
 chart-tests/output/
 dist-newstyle/
+
+test*.png
+test*.svg
+misc*.png
+misc*.svg
+parametric.png
+parametric.svg
+sparklines.png
+sparklines.svg

--- a/chart-tests/tests/Test4.hs
+++ b/chart-tests/tests/Test4.hs
@@ -1,10 +1,10 @@
 module Test4 where 
 
-import Graphics.Rendering.Chart
+import Control.Lens
 import Data.Colour
 import Data.Colour.Names
-import Control.Lens
 import Data.Default.Class
+import Graphics.Rendering.Chart
 
 import Utils
 
@@ -12,10 +12,19 @@ chart :: Bool -> Bool -> Renderable (LayoutPick Double Double Double)
 chart xrev yrev = layoutToRenderable layout
   where
 
+    pointValues = [ (x, 10**x) | x <- [0.5,1,1.5,2,2.5 :: Double] ]
+
     points = plot_points_style .~ filledCircles 3 (opaque red)
-           $ plot_points_values .~ [ (x, 10**x) | x <- [0.5,1,1.5,2,2.5 :: Double] ]
+           $ plot_points_values .~ pointValues
            $ plot_points_title .~ "values"
            $ def
+
+    labels = plot_annotation_hanchor .~ HTA_Left
+           $ plot_annotation_vanchor .~ VTA_Top
+           $ plot_annotation_offset .~ Vector 10 10
+           $ plot_annotation_values .~ [ (x, y, show (x, y)) | (x, y) <- pointValues ]
+           $ def
+
 
     lines = plot_lines_values .~ [ [(x, 10**x) | x <- [0,3]] ]
           $ plot_lines_title .~ "values"
@@ -27,7 +36,7 @@ chart xrev yrev = layoutToRenderable layout
            $ layout_y_axis . laxis_generate .~ autoScaledLogAxis def
            $ layout_y_axis . laxis_title .~ "vertical"
            $ layout_y_axis . laxis_reverse .~ yrev
-           $ layout_plots .~ [ toPlot points, toPlot lines ]
+           $ layout_plots .~ [ toPlot points, toPlot lines, toPlot labels ]
            $ def
 
 -- main = main' "test4" (chart False False)

--- a/chart-tests/tests/Test9.hs
+++ b/chart-tests/tests/Test9.hs
@@ -1,17 +1,18 @@
-module Test9 where 
+module Test9 where
 
-import Graphics.Rendering.Chart
+import Control.Arrow
+import Control.Lens
 import Data.Colour
 import Data.Colour.Names
-import Control.Lens
 import Data.Default.Class
+import Graphics.Rendering.Chart
 
 import Utils
 
 chart :: Bool -> Renderable (LayoutPick PlotIndex Double Double)
 chart borders = layoutToRenderable layout
  where
-  layout = 
+  layout =
         layout_title .~ "Sample Bars" ++ btitle
       $ layout_title_style . font_size .~ 10
       $ layout_x_axis . laxis_generate .~ autoIndexAxis alabels
@@ -21,12 +22,13 @@ chart borders = layoutToRenderable layout
       $ def :: Layout PlotIndex Double
 
   bars2 = plot_bars_titles .~ ["Cash","Equity"]
-      $ plot_bars_values .~ addIndexes [[20,45],[45,30],[30,20],[70,25]]
+      $ plot_bars_values_with_labels .~ addLabels (addIndexes vals)
       $ plot_bars_style .~ BarsClustered
       $ plot_bars_spacing .~ BarsFixGap 30 5
       $ plot_bars_item_styles .~ map mkstyle (cycle defaultColorSeq)
       $ def
 
+  vals = [[20,45],[45,30],[30,20],[70,25]]
   alabels = [ "Jun", "Jul", "Aug", "Sep", "Oct" ]
 
   btitle = if borders then "" else " (no borders)"

--- a/chart-tests/tests/Tests.hs
+++ b/chart-tests/tests/Tests.hs
@@ -5,20 +5,25 @@ import Graphics.Rendering.Chart
 import Graphics.Rendering.Chart.Drawing
 import Graphics.Rendering.Chart.Grid
 
-import System.Time
-import System.Random
-import Data.Time.LocalTime
 import Control.Lens
+import Control.Monad
 import Data.Char (chr)
 import Data.Colour
 import Data.Colour.Names
 import Data.Colour.SRGB
-import Data.List(sort,nub,scanl1)
 import Data.Default.Class
+import Data.List(sort,nub,scanl1)
 import qualified Data.Map as Map
-import Control.Monad
+import Data.Time.LocalTime
 import Prices
+import System.Random
+import System.Time
 import qualified Test1
+import qualified Test14
+import qualified Test14a
+import qualified Test15
+import qualified Test17
+import qualified Test19
 import qualified Test2
 import qualified Test3
 import qualified Test4
@@ -26,11 +31,6 @@ import qualified Test5
 import qualified Test7
 import qualified Test8
 import qualified Test9
-import qualified Test14
-import qualified Test14a
-import qualified Test15
-import qualified Test17
-import qualified Test19
 import qualified TestParametric
 import qualified TestSparkLines
 
@@ -166,14 +166,22 @@ test9 alignment lw = fillBackground fwhite $ (gridToRenderable t)
            $ layout_plots .~ [ plotBars bars ]
            $ def :: Layout PlotIndex Double
 
+    vals1 = [[20],[45],[30],[70]]
     bars1 = plot_bars_titles .~ ["Cash"]
-          $ plot_bars_values .~ addIndexes [[20],[45],[30],[70]]
+          $ plot_bars_values_with_labels .~ addLabels (addIndexes vals1)
           $ plot_bars_alignment .~ alignment
+          $ plot_bars_label_bar_hanchor .~ BHA_Centre
+          $ plot_bars_label_bar_vanchor .~ BVA_Centre
+          $ plot_bars_label_text_hanchor .~ HTA_Centre
           $ def
 
+    vals2 = [[20,45],[45,30],[30,20],[70,25]]
     bars2 = plot_bars_titles .~ ["Cash","Equity"]
-          $ plot_bars_values .~ addIndexes [[20,45],[45,30],[30,20],[70,25]]
+          $ plot_bars_values_with_labels .~ addLabels (addIndexes vals2)
           $ plot_bars_alignment .~ alignment
+          $ plot_bars_label_bar_hanchor .~ BHA_Centre
+          $ plot_bars_label_bar_vanchor .~ BVA_Centre
+          $ plot_bars_label_text_hanchor .~ HTA_Centre
           $ def
 
 -------------------------------------------------------------------------------

--- a/chart/Graphics/Rendering/Chart/Plot/Annotation.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/Annotation.hs
@@ -15,14 +15,15 @@ module Graphics.Rendering.Chart.Plot.Annotation(
     plot_annotation_vanchor,
     plot_annotation_angle,
     plot_annotation_style,
-    plot_annotation_values
+    plot_annotation_values,
+    plot_annotation_offset
 ) where
 
 import Control.Lens
-import Graphics.Rendering.Chart.Geometry
-import Graphics.Rendering.Chart.Drawing
-import Graphics.Rendering.Chart.Plot.Types
 import Data.Default.Class
+import Graphics.Rendering.Chart.Drawing
+import Graphics.Rendering.Chart.Geometry
+import Graphics.Rendering.Chart.Plot.Types
 
 -- | Value for describing a series of text annotations
 --   to be placed at arbitrary points on the graph. Annotations
@@ -34,7 +35,8 @@ data PlotAnnotation  x y = PlotAnnotation {
       _plot_annotation_angle   :: Double,
       -- ^ Angle, in degrees, to rotate the annotation about the anchor point.
       _plot_annotation_style   :: FontStyle,
-      _plot_annotation_values  :: [(x,y,String)]
+      _plot_annotation_values  :: [(x,y,String)],
+      _plot_annotation_offset  :: Vector
 }
 
 
@@ -56,8 +58,9 @@ renderAnnotation p pMap = withFontStyle style $
           values = _plot_annotation_values p
           angle =  _plot_annotation_angle p
           style =  _plot_annotation_style p
+          offset = _plot_annotation_offset p
           drawOne (x,y,s) = drawTextsR hta vta angle point s
-              where point = pMap (LValue x, LValue y)
+              where point = pMap (LValue x, LValue y) `pvadd` offset
 
 instance Default (PlotAnnotation x y) where
   def = PlotAnnotation 
@@ -66,6 +69,7 @@ instance Default (PlotAnnotation x y) where
     , _plot_annotation_angle   = 0
     , _plot_annotation_style   = def
     , _plot_annotation_values  = []
+    , _plot_annotation_offset  = Vector 0 0
     }
 
 $( makeLenses ''PlotAnnotation )


### PR DESCRIPTION
This PR adds the ability to annotate scatter plots and bar graphs with labels. The supported options mirror the arguments of `drawTextR`, with some additional support for controlling position relative to the point/bar.