### PR TITLE
Adding a gtk3 backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ before_cache:
 matrix:
   include:
     - compiler: "ghc-7.6.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3,libgtk2.0-dev,libcairo-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.4"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.4,libgtk2.0-dev,libcairo-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.4,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-7.10.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.3,libgtk2.0-dev,libcairo-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.3,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2,libgtk2.0-dev,libcairo-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,12 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-7.6.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.8.4"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.4,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-7.10.3"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.3,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.2.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2,libgtk2.0-dev,libgtk-3-dev,libcairo-dev], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}
@@ -42,7 +40,7 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
 # prepare `cabal sdist` source-tree environment to make sure source-tarballs are complete
- - read -a PKGS <<< "chart chart-cairo chart-diagrams chart-tests chart-gtk"
+ - read -a PKGS <<< "chart chart-cairo chart-diagrams chart-tests chart-gtk chart-gtk3"
  - rm -rf sdists; mkdir sdists
  - for PKG in "${PKGS[@]}"; do
      cd "$PKG"; cabal sdist --output-directory="../sdists/$PKG" || break; cd ..;

--- a/README.md
+++ b/README.md
@@ -6,5 +6,3 @@ haskell-chart
 A 2D charting library for haskell
 
 Further information can be found in the associated [wiki](https://github.com/timbod7/haskell-chart/wiki).
-
-This is a fork to add gtk3 support via a new chart-gtk3 backend.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ haskell-chart
 A 2D charting library for haskell
 
 Further information can be found in the associated [wiki](https://github.com/timbod7/haskell-chart/wiki).
+
+This is a fork to add gtk3 support via a new chart-gtk3 backend.

--- a/cabal.project
+++ b/cabal.project
@@ -4,3 +4,4 @@ packages:
   chart-diagrams/
   chart-tests/
   chart-gtk/
+  chart-gtk3/

--- a/chart-gtk3/Chart-gtk3.cabal
+++ b/chart-gtk3/Chart-gtk3.cabal
@@ -1,0 +1,32 @@
+Name: Chart-gtk3
+Version: 1.8.3
+License: BSD3
+License-file: LICENSE
+Copyright: Tim Docker, 2006-2014
+Author: Tim Docker <tim@dockerz.net>
+Maintainer: Tim Docker <tim@dockerz.net>
+Homepage: https://github.com/timbod7/haskell-chart/wiki
+Synopsis: Utility functions for using the chart library with GTK
+Description: Utility functions for using the chart library with GTK
+Category: Graphics
+Cabal-Version: >= 1.6
+Build-Type: Simple
+
+library
+  Build-depends: base >= 3 && < 5
+               , old-locale
+               , time, mtl, array
+               , cairo >= 0.9.11
+               , data-default-class < 0.2
+               , colour >= 2.2.1 && < 2.4
+               , colour >= 2.2.1
+               , gtk3 >= 0.14
+               , Chart >= 1.8.3 && < 1.9
+               , Chart-cairo >= 1.8.3 && < 1.9
+
+  Exposed-modules:
+        Graphics.Rendering.Chart.Gtk
+
+source-repository head
+  type:     git
+  location: https://github.com/timbod7/haskell-chart

--- a/chart-gtk3/Graphics/Rendering/Chart/Gtk.hs
+++ b/chart-gtk3/Graphics/Rendering/Chart/Gtk.hs
@@ -1,0 +1,103 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Graphics.Rendering.Chart.Gtk
+-- Copyright   :  (c) Tim Docker 2006
+-- License     :  BSD-style (see chart/COPYRIGHT)
+
+module Graphics.Rendering.Chart.Gtk (
+    renderableToWindow,
+    toWindow,
+    createRenderableWindow,
+    updateCanvas
+    ) where
+
+import qualified Graphics.UI.Gtk as G
+import qualified Graphics.UI.Gtk.Gdk.Events as GE
+import qualified Graphics.Rendering.Cairo as C
+
+import Graphics.Rendering.Chart
+import Graphics.Rendering.Chart.Renderable
+import Graphics.Rendering.Chart.Geometry
+import Graphics.Rendering.Chart.Drawing
+import Graphics.Rendering.Chart.Backend.Cairo
+import Graphics.Rendering.Chart.State(EC, execEC)
+
+import Data.List (isPrefixOf)
+import Data.IORef
+import Data.Default.Class
+
+import Control.Monad(when)
+import System.IO.Unsafe(unsafePerformIO)
+
+
+-- Yuck. But we really want the convenience function
+-- renderableToWindow as to be callable without requiring
+-- initGUI to be called first. But newer versions of
+-- gtk insist that initGUI is only called once
+guiInitVar :: IORef Bool
+{-# NOINLINE guiInitVar #-}
+guiInitVar = unsafePerformIO (newIORef False)
+
+initGuiOnce :: IO ()
+initGuiOnce = do
+    v <- readIORef guiInitVar
+    when (not v) $ do
+        -- G.initGUI
+        G.unsafeInitGUIForThreadedRTS
+        writeIORef guiInitVar True
+
+-- | Display a renderable in a gtk window.
+--
+-- Note that this is a convenience function that initialises GTK on
+-- its first call, but not subsequent calls. Hence it's 
+-- unlikely to be compatible with other code using gtk. In 
+-- that case use createRenderableWindow.
+renderableToWindow :: Renderable a -> Int -> Int -> IO ()
+renderableToWindow chart windowWidth windowHeight = do
+    initGuiOnce
+    window <- createRenderableWindow chart windowWidth windowHeight
+    -- press any key to exit the loop
+    window `G.on` G.keyPressEvent $ do
+                     C.liftIO (G.widgetDestroy window)
+                     return True
+    window `G.on` G.objectDestroy $ G.mainQuit
+    G.widgetShowAll window
+    G.mainGUI
+
+-- | Generate a new GTK window from the state content of
+-- an EC computation. The state may have any type that is
+-- an instance of `ToRenderable`
+toWindow :: (Default r, ToRenderable r) =>Int -> Int -> EC r () -> IO ()
+toWindow windowWidth windowHeight ec = renderableToWindow r windowWidth windowHeight where
+                       r = toRenderable (execEC ec)
+
+-- | Create a new GTK window displaying a renderable.
+createRenderableWindow :: Renderable a -> Int -> Int -> IO G.Window
+createRenderableWindow chart windowWidth windowHeight = do
+    window <- G.windowNew
+    canvas <- G.drawingAreaNew
+    G.widgetSetSizeRequest window windowWidth windowHeight
+    canvas `G.on` G.draw $ do
+      C.liftIO $ updateCanvas chart canvas
+      return ()
+
+    G.set window [G.containerChild G.:= canvas]
+    return window
+
+
+updateCanvas :: Renderable a -> G.DrawingArea  -> IO Bool
+updateCanvas chart canvas = do
+    mwin <- G.widgetGetWindow canvas
+    case mwin of
+      Nothing -> return False
+      Just win -> do
+        width  <- C.liftIO $ G.widgetGetAllocatedWidth canvas
+        height <- C.liftIO $ G.widgetGetAllocatedHeight canvas
+        putStrLn $ "Width = " ++ show width ++ "; Height = " ++ show height
+        let rect = GE.Rectangle 0 0 width height
+        let sz   = (fromIntegral width, fromIntegral height)
+        G.drawWindowBeginPaintRect win rect
+        G.renderWithDrawWindow win
+          $ runBackend (defaultEnv bitmapAlignmentFns) (render chart sz)
+        G.drawWindowEndPaint win
+        return True

--- a/chart-gtk3/Graphics/Rendering/Chart/Gtk.hs
+++ b/chart-gtk3/Graphics/Rendering/Chart/Gtk.hs
@@ -93,7 +93,6 @@ updateCanvas chart canvas = do
       Just win -> do
         width  <- C.liftIO $ G.widgetGetAllocatedWidth canvas
         height <- C.liftIO $ G.widgetGetAllocatedHeight canvas
-        putStrLn $ "Width = " ++ show width ++ "; Height = " ++ show height
         let rect = GE.Rectangle 0 0 width height
         let sz   = (fromIntegral width, fromIntegral height)
         G.drawWindowBeginPaintRect win rect

--- a/chart-gtk3/LICENSE
+++ b/chart-gtk3/LICENSE
@@ -1,0 +1,31 @@
+Copyright (c) 2006, Tim Docker
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * The names of contributors may not be used to endorse or promote
+      products derived from this software without specific prior
+      written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/chart-gtk3/Setup.hs
+++ b/chart-gtk3/Setup.hs
@@ -1,0 +1,8 @@
+#!/usr/bin/env runghc
+
+module Main where
+
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMain

--- a/chart-gtk3/stack.yaml
+++ b/chart-gtk3/stack.yaml
@@ -1,0 +1,21 @@
+# Resolver to choose a 'specific' stackage snapshot or a compiler version.
+# A snapshot resolver dictates the compiler version and the set of packages
+# to be used for project dependencies. For example:
+# 
+# resolver: ghc-8.0.2
+resolver: lts-11.2
+system-ghc: false
+
+# A package marked 'extra-dep: true' will only be built if demanded by a
+# non-dependency (i.e. a user package), and its test suites and benchmarks
+# will not be run. This is useful for tweaking upstream packages.
+packages:
+  - '.'
+
+# Dependency packages to be pulled from upstream that are not in the resolver
+# (e.g., acme-missiles-0.3)
+extra-deps:
+  - Chart-1.8.3
+  - Chart-cairo-1.8.3
+  - gio-0.13.4.1
+  - gtk3-0.14.8


### PR DESCRIPTION
I added a chart-gtk3 backend, which is basically chart-gtk converted to use the changed gtk3 library API.
I tested it with my own applications with ghc-8.0.1, ghc-8.0.2 and stack lts-11.2.  It also worked with
the current nix developent version.  The nix release uses Chart 1.8.2, but it I use the 1.8.3 from hackage it sees to work fine.  It seems with ghc-8.4.1 there are still issues building the gtk2hs cabal library.

I find Chart very useful, and would like to help keep it alive.  As  gtk2 is faded out, I think it would be helpful to keep a gtk3 backend in the project, even if it only serves as example code.
Long term, things might be moving from gtk2hs to haskell-gi.  Are you interested in moving in that direction?