### PR TITLE
updates for new SVGFonts (in order to be added to Stackage)

### DIFF
--- a/chart-diagrams/Chart-diagrams.cabal
+++ b/chart-diagrams/Chart-diagrams.cabal
@@ -32,7 +32,7 @@ library
                , diagrams-lib >= 1.2 && < 1.5
                , diagrams-svg >= 1.4 && < 1.5
                , diagrams-postscript >= 0.7 && < 1.5
-               , SVGFonts >= 1.4 && < 1.7
+               , SVGFonts >= 1.4 && < 1.8
                , colour >= 2.2.1 && < 2.4
                , blaze-markup >= 0.7 && < 0.9
                , svg-builder >= 0.1 && < 0.2

--- a/chart-diagrams/Chart-diagrams.cabal
+++ b/chart-diagrams/Chart-diagrams.cabal
@@ -32,7 +32,7 @@ library
                , diagrams-lib >= 1.2 && < 1.5
                , diagrams-svg >= 1.4 && < 1.5
                , diagrams-postscript >= 0.7 && < 1.5
-               , SVGFonts >= 1.4 && < 1.8
+               , SVGFonts >= 1.7 && < 1.8
                , colour >= 2.2.1 && < 2.4
                , blaze-markup >= 0.7 && < 0.9
                , svg-builder >= 0.1 && < 0.2

--- a/chart-diagrams/Graphics/Rendering/Chart/Backend/Diagrams.hs
+++ b/chart-diagrams/Graphics/Rendering/Chart/Backend/Diagrams.hs
@@ -568,7 +568,7 @@ fontStyleToTextOpts env =
       , F.textHeight = scaledH -- _font_size fs
       }
 
-fontFromName :: (Read n, RealFloat n) => String -> F.PreparedFont n
+fontFromName :: (Read n, RealFloat n) => String -> IO (F.PreparedFont n)
 fontFromName name = case name of
   "serif" -> F.lin
   "monospace" -> F.bit


### PR DESCRIPTION
I bumped the version bound and changed fontsFromName to return IO. I don't know if this is an acceptable change, also not all of the sub-packages work with the latest stackage nightly, but Chart and Chart-diagrams do, and if this is accepted (and subsequently pushed to Hackage), I will add Chart and Chart-diagrams to stackage.