### PR TITLE
Add PlotValue instances for more Int and Word types

### DIFF
--- a/chart/Graphics/Rendering/Chart/Axis/Int.hs
+++ b/chart/Graphics/Rendering/Chart/Axis/Int.hs
@@ -14,11 +14,58 @@ module Graphics.Rendering.Chart.Axis.Int(
 ) where
 
 import Data.List(genericLength)
+import Data.Int (Int8, Int16, Int32, Int64)
+import Data.Word (Word8, Word16, Word32, Word64)
 import Graphics.Rendering.Chart.Geometry
 import Graphics.Rendering.Chart.Axis.Types
 import Graphics.Rendering.Chart.Axis.Floating
 
 instance PlotValue Int where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Int8 where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Int16 where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Int32 where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Int64 where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Word where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Word8 where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Word16 where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Word32 where
+    toValue    = fromIntegral
+    fromValue  = round
+    autoAxis   = autoScaledIntAxis defaultIntAxis
+
+instance PlotValue Word64 where
     toValue    = fromIntegral
     fromValue  = round
     autoAxis   = autoScaledIntAxis defaultIntAxis


### PR DESCRIPTION
This is a simple change to add instances for more Integral types. Since I needed to plot Word32 values, and though it would make the library a bit easier to use, in those cases.

I looked into doing it more generalized for Integrals, but it seemed to be more hassle, than its worth. 

If you want me to change something, please say, and I will look into it.  