### PR TITLE
Fix errors during `stack test`.

### DIFF
--- a/chart-tests/Chart-tests.cabal
+++ b/chart-tests/Chart-tests.cabal
@@ -42,7 +42,9 @@ Executable chart-harness
     diagrams-svg    >= 1.4 && < 1.5,
     diagrams-postscript    >= 0.7 && < 1.6,
     diagrams-lib    >= 1.2 && < 1.5,
-    diagrams-core   >= 1.3 && < 1.5
+    diagrams-core   >= 1.3 && < 1.5,
+    vector          >= 0.9 && < 0.13,
+    QuickCheck      >= 2.10 && < 2.12
   Main-is: Main.hs
   Hs-Source-Dirs: tests
   Ghc-Options: -threaded


### PR DESCRIPTION
I was unable to successfully run `stack test` on my machine (Debian 10, Stack version 2.5.1.1). There were two reasons:

**1.**

Adding `vector` fixes the error

Chart-tests> ../chart/Numeric/Histogram.hs:10:1: error:
Chart-tests>     Could not find module ‘Data.Vector’

**2.**

Adding `QuickCheck` fixes the error

Chart-tests> <interactive>:74:3: error:
Chart-tests>     Variable not in scope:
Chart-tests>       polyQuickCheck

This seems to be exactly the issue mentioned at https://hackage.haskell.org/package/cabal-doctest-1.0.8 (search for the text "Variable not in scope" on that web page).