### PR TITLE
make it build with newer versions

### DIFF
--- a/chart-diagrams/Chart-diagrams.cabal
+++ b/chart-diagrams/Chart-diagrams.cabal
@@ -28,7 +28,7 @@ library
   Build-depends: base >= 3 && < 5
                , old-locale
                , time, mtl
-               , diagrams-core >= 1.3 && <= 1.5
+               , diagrams-core >= 1.3 && < 1.6
                , diagrams-lib >= 1.2 && < 1.5
                , diagrams-svg >= 1.4 && < 1.5
                , diagrams-postscript >= 0.7 && < 1.6

--- a/chart-diagrams/Chart-diagrams.cabal
+++ b/chart-diagrams/Chart-diagrams.cabal
@@ -28,7 +28,7 @@ library
   Build-depends: base >= 3 && < 5
                , old-locale
                , time, mtl
-               , diagrams-core >= 1.3 && < 1.5
+               , diagrams-core >= 1.3 && <= 1.5
                , diagrams-lib >= 1.2 && < 1.5
                , diagrams-svg >= 1.4 && < 1.5
                , diagrams-postscript >= 0.7 && < 1.6


### PR DESCRIPTION
using ghc 8.10.7, build-fails using latest chart and chart-diagram packages (1.9.3)

culprit is chart-diagrams requiring `diagram-core < 1.5` that needs `base < 4.14`, which other packages conflict with i guess ?

`diagram-core` 1.5 sets `base` bounds to < 4.16