### PR TITLE
chart-diagrams/Chart-diagrams.cabal: bump `lens`

### DIFF
--- a/chart-diagrams/Chart-diagrams.cabal
+++ b/chart-diagrams/Chart-diagrams.cabal
@@ -40,7 +40,7 @@ library
                , operational >= 0.2.2 && < 0.3
                , containers >= 0.4 && < 0.7
                , data-default-class < 0.2
-               , lens >= 3.9 && < 4.20
+               , lens >= 3.9 && < 5.1
                , Chart >= 1.9 && < 1.10
                , text
   other-modules: Paths_Chart_diagrams


### PR DESCRIPTION
This brings the bounds in line with those specified in [revision 2](https://hackage.haskell.org/package/Chart-diagrams-1.9.3/revision/2.cabal) of the latest currently uploaded version on Hackage.