### PR TITLE
Allow mtl-2.3

### DIFF
--- a/chart/Chart.cabal
+++ b/chart/Chart.cabal
@@ -21,11 +21,11 @@ library
   default-language: Haskell98
   Build-depends: base >= 3 && < 5
                , old-locale
-               , time, mtl, array
+               , time, array
                , lens >= 3.9 && < 5.2
                , colour >= 2.2.1 && < 2.4
                , data-default-class < 0.2
-               , mtl >= 2.0 && < 2.3
+               , mtl >= 2.0 && < 2.4
                , operational >= 0.2.2 && < 0.3
                , vector >=0.9 && <0.13
 

--- a/chart/Graphics/Rendering/Chart/Backend/Impl.hs
+++ b/chart/Graphics/Rendering/Chart/Backend/Impl.hs
@@ -10,7 +10,7 @@
 
 module Graphics.Rendering.Chart.Backend.Impl where
 
-import Control.Monad.Reader
+import Control.Monad
 import Control.Monad.Operational
 
 import Graphics.Rendering.Chart.Geometry

--- a/chart/Graphics/Rendering/Chart/Backend/Impl.hs
+++ b/chart/Graphics/Rendering/Chart/Backend/Impl.hs
@@ -22,20 +22,20 @@ import Graphics.Rendering.Chart.Backend.Types
 
 -- | The abstract drawing operation generated when using the
 --   the chart drawing API.
---   
+--
 --   See the documentation of the different function for the correct semantics
 --   of each instruction:
---   
+--
 --   * 'strokePath', 'fillPath'
---   
+--
 --   * 'drawText', 'textSize'
---   
+--
 --   * 'getPointAlignFn', 'getCoordAlignFn', 'AlignmentFns'
---   
+--
 --   * 'withTransform', 'withClipRegion'
---   
+--
 --   * 'withLineStyle', 'withFillStyle', 'withFontStyle'
---   
+--
 data ChartBackendInstr a where
   StrokePath :: Path -> ChartBackendInstr ()
   FillPath   :: Path -> ChartBackendInstr ()
@@ -49,22 +49,22 @@ data ChartBackendInstr a where
   WithClipRegion :: Rect -> Program ChartBackendInstr a -> ChartBackendInstr a
 
 -- | A 'BackendProgram' provides the capability to render a chart somewhere.
---   
+--
 --   The coordinate system of the backend has its initial origin (0,0)
---   in the top left corner of the drawing plane. The x-axis points 
---   towards the top right corner and the y-axis points towards 
+--   in the top left corner of the drawing plane. The x-axis points
+--   towards the top right corner and the y-axis points towards
 --   the bottom left corner. The unit used by coordinates, the font size,
 --   and lengths is the always the same, but depends on the backend.
 --   All angles are measured in radians.
---   
---   The line, fill and font style are set to their default values 
+--
+--   The line, fill and font style are set to their default values
 --   initially.
---   
---   Information about the semantics of the instructions can be 
+--
+--   Information about the semantics of the instructions can be
 --   found in the documentation of 'ChartBackendInstr'.
 type BackendProgram a = Program ChartBackendInstr a
 
--- | Stroke the outline of the given path using the 
+-- | Stroke the outline of the given path using the
 --   current 'LineStyle'. This function does /not/ perform
 --   alignment operations on the path. See 'Path' for the exact semantic
 --   of paths.
@@ -84,13 +84,13 @@ fillPath p = singleton (FillPath p)
 textSize :: String -> BackendProgram TextSize
 textSize text = singleton (GetTextSize text)
 
--- | Draw a single-line textual label anchored by the baseline (vertical) 
+-- | Draw a single-line textual label anchored by the baseline (vertical)
 --   left (horizontal) point. Uses the current 'FontStyle' for drawing.
 drawText :: Point -> String -> BackendProgram ()
 drawText p text = singleton (DrawText p text)
 
 -- | Apply the given transformation in this local
---   environment when drawing. The given transformation 
+--   environment when drawing. The given transformation
 --   is applied after the current transformation. This
 --   means both are combined.
 withTransform :: Matrix -> BackendProgram a -> BackendProgram a
@@ -98,11 +98,11 @@ withTransform t p = singleton (WithTransform t p)
 
 -- | Use the given font style in this local
 --   environment when drawing text.
---   
+--
 --   An implementing backend is expected to guarentee
 --   to support the following font families: @serif@, @sans-serif@ and @monospace@;
---   
---   If the backend is not able to find or load a given font 
+--
+--   If the backend is not able to find or load a given font
 --   it is required to fall back to a custom fail-safe font
 --   and use it instead.
 withFontStyle :: FontStyle -> BackendProgram a -> BackendProgram a
@@ -120,7 +120,7 @@ withLineStyle ls p = singleton (WithLineStyle ls p)
 
 -- | Use the given clipping rectangle when drawing
 --   in this local environment. The new clipping region
---   is intersected with the given clip region. You cannot 
+--   is intersected with the given clip region. You cannot
 --   escape the clip!
 withClipRegion :: Rect -> BackendProgram a -> BackendProgram a
 withClipRegion c p = singleton (WithClipRegion c p)

--- a/chart/Graphics/Rendering/Chart/Drawing.hs
+++ b/chart/Graphics/Rendering/Chart/Drawing.hs
@@ -27,20 +27,20 @@ module Graphics.Rendering.Chart.Drawing
     PointShape(..)
   , PointStyle(..)
   , drawPoint
-  
+
   -- * Alignments and Paths
   , alignPath
   , alignFillPath
   , alignStrokePath
   , alignFillPoints
   , alignStrokePoints
-  
+
   , alignFillPoint
   , alignStrokePoint
-  
+
   , strokePointPath
   , fillPointPath
-  
+
   -- * Transformation and Style Helpers
   , withRotation
   , withTranslation
@@ -48,17 +48,17 @@ module Graphics.Rendering.Chart.Drawing
   , withScaleX, withScaleY
   , withPointStyle
   , withDefaultStyle
-  
+
   -- * Text Drawing
   , drawTextA
   , drawTextR
   , drawTextsR
   , textDrawRect
   , textDimension
-  
+
   -- * Style Helpers
   , defaultColorSeq
-    
+
   , solidLine
   , dashedLine
 
@@ -70,12 +70,12 @@ module Graphics.Rendering.Chart.Drawing
   , exes
   , stars
   , arrows
-    
+
   , solidFillStyle
-  
+
   -- * Backend and general Types
   , module Graphics.Rendering.Chart.Backend
-  
+
   -- * Accessors
   , point_color
   , point_border_color
@@ -127,8 +127,8 @@ withScaleY y = withScale (Vector 1 y)
 -- | Changes the 'LineStyle' and 'FillStyle' to comply with
 --   the given 'PointStyle'.
 withPointStyle :: PointStyle -> BackendProgram a -> BackendProgram a
-withPointStyle (PointStyle cl bcl bw _ _) m = 
-  withLineStyle (def { _line_color = bcl, _line_width = bw, _line_join = LineJoinMiter }) $ 
+withPointStyle (PointStyle cl bcl bw _ _) m =
+  withLineStyle (def { _line_color = bcl, _line_width = bw, _line_join = LineJoinMiter }) $
     withFillStyle (solidFillStyle cl) m
 
 withDefaultStyle :: BackendProgram a -> BackendProgram a
@@ -147,7 +147,7 @@ alignPath f = foldPath (G.moveTo . f)
                        close
 
 -- | Align the path using the environment's alignment function for points.
---   This is generally useful when stroking. 
+--   This is generally useful when stroking.
 --   See 'alignPath' and 'getPointAlignFn'.
 alignStrokePath :: Path -> BackendProgram Path
 alignStrokePath p = do
@@ -155,7 +155,7 @@ alignStrokePath p = do
   return $ alignPath f p
 
 -- | Align the path using the environment's alignment function for coordinates.
---   This is generally useful when filling. 
+--   This is generally useful when filling.
 --   See 'alignPath' and 'getCoordAlignFn'.
 alignFillPath :: Path -> BackendProgram Path
 alignFillPath p = do
@@ -181,14 +181,14 @@ alignFillPoints p = do
 -- | Align the point using the environment's alignment function for points.
 --   See 'getPointAlignFn'.
 alignStrokePoint :: Point -> BackendProgram Point
-alignStrokePoint p = do 
+alignStrokePoint p = do
     alignfn <- getPointAlignFn
     return (alignfn p)
 
 -- | Align the point using the environment's alignment function for coordinates.
 --   See 'getCoordAlignFn'.
 alignFillPoint :: Point -> BackendProgram Point
-alignFillPoint p = do 
+alignFillPoint p = do
     alignfn <- getCoordAlignFn
     return (alignfn p)
 
@@ -216,19 +216,19 @@ fillPointPath pts = fillPath $ stepPath pts
 drawTextA :: HTextAnchor -> VTextAnchor -> Point -> String -> BackendProgram ()
 drawTextA hta vta = drawTextR hta vta 0
 
-{- 
+{-
    The following is useful for checking out the bounding-box
    calculation. At present it looks okay for PNG/Cairo but
    is a bit off for SVG/Diagrams; this may well be down to
    differences in how fonts are rendered in the two backends
 
 drawTextA hta vta p txt =
-  drawTextR hta vta 0 p txt 
-  >> withLineStyle (solidLine 1 (opaque red)) 
+  drawTextR hta vta 0 p txt
+  >> withLineStyle (solidLine 1 (opaque red))
      (textDrawRect hta vta p txt
        >>= \rect -> alignStrokePath (rectPath rect) >>= strokePath)
 -}
-  
+
 -- | Draw a textual label anchored by one of its corners
 --   or edges, with rotation. Rotation angle is given in degrees,
 --   rotation is performed around anchor point.
@@ -250,7 +250,7 @@ drawTextsR :: HTextAnchor -> VTextAnchor -> Double -> Point -> String -> Backend
 drawTextsR hta vta angle p s = case num of
       0 -> return ()
       1 -> drawTextR hta vta angle p s
-      _ -> 
+      _ ->
         withTranslation p $
           withRotation theta $ do
             tss <- mapM textSize ss
@@ -319,7 +319,7 @@ textDimension :: String -> BackendProgram RectSize
 textDimension s = do
   ts <- textSize s
   return (textSizeWidth ts, textSizeHeight ts)
-  
+
 -- -----------------------------------------------------------------------
 -- Point Types and Drawing
 -- -----------------------------------------------------------------------
@@ -349,7 +349,7 @@ data PointStyle = PointStyle
 
 -- | Default style to use for points.
 instance Default PointStyle where
-  def = PointStyle 
+  def = PointStyle
     { _point_color        = opaque black
     , _point_border_color = transparent
     , _point_border_width = 0
@@ -382,7 +382,7 @@ drawPoint ps@(PointStyle cl _ _ r shape) p = withPointStyle ps $ do
     PointShapeArrowHead theta ->
       withTranslation p $ withRotation (theta - pi/2) $
           drawPoint (filledPolygon r 3 True cl) (Point 0 0)
-    PointShapePlus -> 
+    PointShapePlus ->
       strokePath $ moveTo' (x+r) y
                 <> lineTo' (x-r) y
                 <> moveTo' x (y-r)
@@ -435,7 +435,7 @@ dashedLine w ds cl = LineStyle w cl ds LineCapButt LineJoinMiter
 filledCircles :: Double             -- ^ Radius of circle.
               -> AlphaColour Double -- ^ Fill colour.
               -> PointStyle
-filledCircles radius cl = 
+filledCircles radius cl =
   PointStyle cl transparent 0 radius PointShapeCircle
 
 -- | Style for stroked circle points.
@@ -443,7 +443,7 @@ hollowCircles :: Double -- ^ Radius of circle.
               -> Double -- ^ Thickness of line.
               -> AlphaColour Double -- Colour of line.
               -> PointStyle
-hollowCircles radius w cl = 
+hollowCircles radius w cl =
   PointStyle transparent cl w radius PointShapeCircle
 
 -- | Style for stroked polygon points.
@@ -453,7 +453,7 @@ hollowPolygon :: Double -- ^ Radius of circle.
               -> Bool   -- ^ Is right-side-up?
               -> AlphaColour Double -- ^ Colour of line.
               -> PointStyle
-hollowPolygon radius w sides isrot cl = 
+hollowPolygon radius w sides isrot cl =
   PointStyle transparent cl w radius (PointShapePolygon sides isrot)
 
 -- | Style for filled polygon points.
@@ -462,7 +462,7 @@ filledPolygon :: Double -- ^ Radius of circle.
               -> Bool   -- ^ Is right-side-up?
               -> AlphaColour Double -- ^ Fill color.
               -> PointStyle
-filledPolygon radius sides isrot cl = 
+filledPolygon radius sides isrot cl =
   PointStyle cl transparent 0 radius (PointShapePolygon sides isrot)
 
 -- | Plus sign point style.
@@ -470,7 +470,7 @@ plusses :: Double -- ^ Radius of tightest surrounding circle.
         -> Double -- ^ Thickness of line.
         -> AlphaColour Double -- ^ Color of line.
         -> PointStyle
-plusses radius w cl = 
+plusses radius w cl =
   PointStyle transparent cl w radius PointShapePlus
 
 -- | Cross point style.

--- a/chart/Graphics/Rendering/Chart/Drawing.hs
+++ b/chart/Graphics/Rendering/Chart/Drawing.hs
@@ -95,7 +95,6 @@ import Control.Lens
 import Data.Colour
 import Data.Colour.Names
 import Data.List (unfoldr)
-import Data.Monoid
 
 import Graphics.Rendering.Chart.Backend
 import Graphics.Rendering.Chart.Geometry hiding (moveTo)

--- a/chart/Graphics/Rendering/Chart/Geometry.hs
+++ b/chart/Graphics/Rendering/Chart/Geometry.hs
@@ -53,8 +53,6 @@ module Graphics.Rendering.Chart.Geometry
 
 import qualified Prelude
 import Prelude hiding ((^))
-import Data.Monoid (Monoid (..))
-import Data.Semigroup (Semigroup(..))
 
 -- The homomorphic version to avoid casts inside the code.
 (^) :: Num a => a -> Integer -> a

--- a/chart/Graphics/Rendering/Chart/Plot/Candle.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/Candle.hs
@@ -74,7 +74,7 @@ instance ToPlot PlotCandle where
         pts = _plot_candle_values p
 
 renderPlotCandle :: PlotCandle x y -> PointMapFn x y -> BackendProgram ()
-renderPlotCandle p pmap = 
+renderPlotCandle p pmap =
     mapM_ (drawCandle p . candlemap) (_plot_candle_values p)
   where
     candlemap (Candle x lo op mid cl hi) =
@@ -95,7 +95,7 @@ drawCandle ps (Candle x lo open mid close hi) = do
         -- the pixel coordinate system is inverted wrt the value coords.
         when f $ withFillStyle (if open >= close
                                    then _plot_candle_rise_fill_style ps
-                                   else _plot_candle_fall_fill_style ps) $ 
+                                   else _plot_candle_fall_fill_style ps) $
                     fillPath $ moveTo' (x-wd) open
                             <> lineTo' (x-wd) close
                             <> lineTo' (x+wd) close
@@ -118,7 +118,7 @@ drawCandle ps (Candle x lo open mid close hi) = do
                                     <> lineTo' (x+tl) lo
                                     <> moveTo' (x-tl) hi
                                     <> lineTo' (x+tl) hi
-          
+
           when (ct > 0) $ strokePath $ moveTo' (x-ct) mid
                                     <> lineTo' (x+ct) mid
 
@@ -136,7 +136,7 @@ renderPlotLegendCandle pc (Rect p1 p2) = do
     close = (mid + hi) / 2
 
 instance Default (PlotCandle x y) where
-  def = PlotCandle 
+  def = PlotCandle
     { _plot_candle_title       = ""
     , _plot_candle_line_style  = solidLine 1 $ opaque blue
     , _plot_candle_fill        = False

--- a/chart/Graphics/Rendering/Chart/Plot/Candle.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/Candle.hs
@@ -24,7 +24,6 @@ module Graphics.Rendering.Chart.Plot.Candle(
 ) where
 
 import Control.Lens hiding (op)
-import Data.Monoid
 
 import Graphics.Rendering.Chart.Geometry hiding (close)
 import Graphics.Rendering.Chart.Drawing

--- a/chart/Graphics/Rendering/Chart/Plot/ErrBars.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/ErrBars.hs
@@ -75,7 +75,7 @@ instance ToPlot PlotErrBars where
         pts = _plot_errbars_values p
 
 renderPlotErrBars :: PlotErrBars x y -> PointMapFn x y -> BackendProgram ()
-renderPlotErrBars p pmap = 
+renderPlotErrBars p pmap =
     mapM_ (drawErrBar.epmap) (_plot_errbars_values p)
   where
     epmap (ErrPoint (ErrValue xl x xh) (ErrValue yl y yh)) =
@@ -90,7 +90,7 @@ drawErrBar0 :: PlotErrBars x y -> ErrPoint Double Double -> BackendProgram ()
 drawErrBar0 ps (ErrPoint (ErrValue xl x xh) (ErrValue yl y yh)) = do
         let tl = _plot_errbars_tick_length ps
         let oh = _plot_errbars_overhang ps
-        withLineStyle (_plot_errbars_line_style ps) $ 
+        withLineStyle (_plot_errbars_line_style ps) $
           strokePath $ moveTo' (xl-oh) y
                     <> lineTo' (xh+oh) y
                     <> moveTo' x (yl-oh)
@@ -116,7 +116,7 @@ renderPlotLegendErrBars p (Rect p1 p2) = do
     y          = (p_y p1 + p_y p2)/2
 
 instance Default (PlotErrBars x y) where
-  def = PlotErrBars 
+  def = PlotErrBars
     { _plot_errbars_title       = ""
     , _plot_errbars_line_style  = solidLine 1 $ opaque blue
     , _plot_errbars_tick_length = 3

--- a/chart/Graphics/Rendering/Chart/Plot/ErrBars.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/ErrBars.hs
@@ -25,7 +25,6 @@ module Graphics.Rendering.Chart.Plot.ErrBars(
 ) where
 
 import Control.Lens
-import Data.Monoid
 
 import Graphics.Rendering.Chart.Geometry
 import Graphics.Rendering.Chart.Drawing

--- a/chart/Graphics/Rendering/Chart/Plot/Histogram.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/Histogram.hs
@@ -21,7 +21,6 @@ module Graphics.Rendering.Chart.Plot.Histogram
   ) where
 
 import Control.Monad (when)
-import Data.Monoid
 import Data.Maybe (fromMaybe)
 import qualified Data.Foldable as F
 import qualified Data.Vector as V

--- a/chart/Graphics/Rendering/Chart/Plot/Pie.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/Pie.hs
@@ -24,7 +24,7 @@ module Graphics.Rendering.Chart.Plot.Pie(
     PieLayout(..),
     PieChart(..),
     PieItem(..),
-    
+
     pieToRenderable,
     pieChartToRenderable,
 
@@ -71,7 +71,7 @@ data PieChart = PieChart {
    _pie_data             :: [PieItem],
    _pie_colors           :: [AlphaColour Double],
    _pie_label_style      :: FontStyle,
-   _pie_label_line_style :: LineStyle, 
+   _pie_label_line_style :: LineStyle,
    _pie_start_angle      :: Double
 
 }
@@ -83,7 +83,7 @@ data PieItem = PieItem {
 }
 
 instance Default PieChart where
-  def = PieChart 
+  def = PieChart
     { _pie_data             = []
     , _pie_colors           = defaultColorSeq
     , _pie_label_style      = def
@@ -95,7 +95,7 @@ instance Default PieItem where
   def = PieItem "" 0 0
 
 instance Default PieLayout where
-  def = PieLayout 
+  def = PieLayout
     { _pie_background  = solidFillStyle $ opaque white
     , _pie_title       = ""
     , _pie_title_style = def { _font_size   = 15
@@ -152,10 +152,10 @@ renderPie p (w,h) = do
     foldM_ (paint center radius) (_pie_start_angle p)
            (zip (_pie_colors p) content)
     return nullPickFn
- 
+
     where
-        -- p1 = Point 0 0 
-        -- p2 = Point w h 
+        -- p1 = Point 0 0
+        -- p2 = Point w h
         content = let total = sum (map _pitem_value (_pie_data p))
                   in [ pitem{_pitem_value=_pitem_value pitem/total}
                      | pitem <- _pie_data p ]
@@ -175,13 +175,13 @@ renderPie p (w,h) = do
 
             where
                 pieLabel :: String -> Double -> Double -> BackendProgram ()
-                pieLabel name angle offset = 
-                    withFontStyle (_pie_label_style p) $ 
+                pieLabel name angle offset =
+                    withFontStyle (_pie_label_style p) $
                       withLineStyle (_pie_label_line_style p) $ do
                         let p1 = ray angle (radius+label_rgap+label_rlength+offset)
                         p1a <- alignStrokePoint p1
                         (tw,_) <- textDimension name
-                        let (offset',anchor) = if angle < 90 || angle > 270 
+                        let (offset',anchor) = if angle < 90 || angle > 270
                                               then ((0+),HTA_Left)
                                               else ((0-),HTA_Right)
                         p0 <- alignStrokePoint $ ray angle (radius + label_rgap+offset)
@@ -199,9 +199,9 @@ renderPie p (w,h) = do
                             <> lineTo' x y
                             <> close
 
-                    withFillStyle (FillStyleSolid pColor) $ 
+                    withFillStyle (FillStyleSolid pColor) $
                       fillPath path
-                    withLineStyle (def { _line_color = withOpacity white 0.1 }) $ 
+                    withLineStyle (def { _line_color = withOpacity white 0.1 }) $
                       strokePath path
 
                 ray :: Double -> Double -> Point

--- a/chart/Graphics/Rendering/Chart/Plot/Pie.hs
+++ b/chart/Graphics/Rendering/Chart/Plot/Pie.hs
@@ -50,7 +50,6 @@ module Graphics.Rendering.Chart.Plot.Pie(
 import Control.Lens
 import Data.Colour
 import Data.Colour.Names (white)
-import Data.Monoid
 import Data.Default.Class
 import Control.Monad
 

--- a/chart/Graphics/Rendering/Chart/Renderable.hs
+++ b/chart/Graphics/Rendering/Chart/Renderable.hs
@@ -42,7 +42,6 @@ module Graphics.Rendering.Chart.Renderable(
 
 import Control.Monad
 import Control.Lens
-import Data.Monoid
 import Data.Default.Class
 
 import Graphics.Rendering.Chart.Geometry

--- a/chart/Graphics/Rendering/Chart/Renderable.hs
+++ b/chart/Graphics/Rendering/Chart/Renderable.hs
@@ -17,7 +17,7 @@ module Graphics.Rendering.Chart.Renderable(
     PickFn,
     Rectangle(..),
     RectCornerStyle(..),
-    
+
     rectangleToRenderable,
     drawRectangle,
 
@@ -83,7 +83,7 @@ emptyRenderable :: Renderable a
 emptyRenderable = spacer (0,0)
 
 -- | Create a blank renderable with a specified minimum size.
-spacer :: RectSize -> Renderable a 
+spacer :: RectSize -> Renderable a
 spacer sz  = Renderable {
    minsize = return sz,
    render  = \_ -> return nullPickFn
@@ -118,7 +118,7 @@ addMargins (t,b,l,r) rd = Renderable { minsize = mf, render = rf }
         (w,h) <- minsize rd
         return (w+l+r,h+t+b)
 
-    rf (w,h) = 
+    rf (w,h) =
         withTranslation (Point l t) $ do
           pickf <- render rd (w-l-r,h-t-b)
           return (mkpickf pickf (t,b,l,r) (w,h))
@@ -162,27 +162,27 @@ rlabel fs hta vta rot s = Renderable { minsize = mf, render = rf }
        ts <- textSize s
        let sz = (textSizeWidth ts, textSizeHeight ts)
        return (xwid sz, ywid sz)
-       
+
     rf (w0,h0) = withFontStyle fs $ do
       ts <- textSize s
       let sz@(w,h) = (textSizeWidth ts, textSizeHeight ts)
           descent = textSizeDescent ts
-          
+
           xadj HTA_Left   = xwid sz/2
           xadj HTA_Centre = w0/2
           xadj HTA_Right  = w0 - xwid sz/2
-    
+
           yadj VTA_Top      = ywid sz/2
           yadj VTA_Centre   = h0/2
           yadj VTA_Bottom   = h0 - ywid sz/2
           yadj VTA_BaseLine = h0 - ywid sz/2 + descent*acr
 
-      withTranslation (Point 0 (-descent)) $ 
-        withTranslation (Point (xadj hta) (yadj vta)) $ 
+      withTranslation (Point 0 (-descent)) $
+        withTranslation (Point (xadj hta) (yadj vta)) $
           withRotation rot' $ do
             drawText (Point (-w/2) (h/2)) s
             return (\_-> Just s)  -- PickFn String
-            
+
     rot'      = rot / 180 * pi
     (cr,sr)   = (cos rot', sin rot')
     (acr,asr) = (abs cr, abs sr)
@@ -231,22 +231,22 @@ drawRectangle point rectangle = do
   return nullPickFn
     where
       size = _rect_minsize rectangle
- 
-      fill p sz fs = 
-          withFillStyle fs $ 
+
+      fill p sz fs =
+          withFillStyle fs $
             fillPath $ strokeRectangleP p sz (_rect_cornerStyle rectangle)
- 
-      stroke p sz ls = 
-          withLineStyle ls $ 
+
+      stroke p sz ls =
+          withLineStyle ls $
             strokePath $ strokeRectangleP p sz (_rect_cornerStyle rectangle)
- 
+
       strokeRectangleP (Point x1 y1) (x2,y2) RCornerSquare =
           let (x3,y3) = (x1+x2,y1+y2) in moveTo' x1 y1
                                       <> lineTo' x1 y3
                                       <> lineTo' x3 y3
                                       <> lineTo' x3 y1
                                       <> lineTo' x1 y1
-                                  
+
       strokeRectangleP (Point x1 y1) (x2,y2) (RCornerBevel s) =
           let (x3,y3) = (x1+x2,y1+y2) in moveTo' x1 (y1+s)
                                       <> lineTo' x1 (y3-s)
@@ -257,7 +257,7 @@ drawRectangle point rectangle = do
                                       <> lineTo' (x3-s) y1
                                       <> lineTo' (x1+s) y1
                                       <> lineTo' x1 (y1+s)
- 
+
       strokeRectangleP (Point x1 y1) (x2,y2) (RCornerRounded s) =
           let (x3,y3) = (x1+x2,y1+y2) in
             arcNeg (Point (x1+s) (y3-s)) s (pi2*2) pi2
@@ -265,7 +265,7 @@ drawRectangle point rectangle = do
             <> arcNeg (Point (x3-s) (y1+s)) s 0 (pi2*3)
             <> arcNeg (Point (x1+s) (y1+s)) s (pi2*3) (pi2*2)
             <> lineTo' x1 (y3-s)
-      
+
       pi2 = pi / 2
 
 $( makeLenses ''Rectangle )


### PR DESCRIPTION
`mtl-2.3.1` dropped the `Control.Monad` reexport, so need to `import
Control.Monad`. This makes some imports of `mtl` modules unnecessary.

This PR also removes imports that were causing unused import warnings, trims some trailing whitespace, and fixes the line endings in the `Graphics.Rendering.Chart.Plot.Pie` module which were CRLF for some reason while others were LF.