### PR TITLE
bump vector dependency for Chart

### DIFF
--- a/chart/Chart.cabal
+++ b/chart/Chart.cabal
@@ -27,7 +27,7 @@ library
                , data-default-class < 0.2
                , mtl >= 2.0 && < 2.4
                , operational >= 0.2.2 && < 0.3
-               , vector >=0.9 && <0.13
+               , vector >=0.9 && <0.14
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups >= 0.18.4 && <0.19


### PR DESCRIPTION
Chart builds and seems to work fine with vector 0.13.*, so I've bumped the dependency upper bound.