### PR TITLE
handle null values in stacked bars more carefully

### DIFF
--- a/chart-tests/tests/Test20.hs
+++ b/chart-tests/tests/Test20.hs
@@ -65,6 +65,7 @@ chart = layoutToRenderable layout
       $ layout_y_axis . laxis_override .~ axisGridAtTicks
       $ layout_y_axis . laxis_reverse .~ True
       $ layout_y_axis . laxis_style . axis_grid_style .~ solidLine 0.3 (opaque lightgrey)
+      $ layout_y_axis . laxis_style . axis_label_style . font_size .~ 9
       $ layout_left_axis_visibility . axis_show_ticks .~ False
 
       -- data

--- a/chart-tests/tests/Test20.hs
+++ b/chart-tests/tests/Test20.hs
@@ -11,7 +11,10 @@ import Utils
 import Test.QuickCheck (Result(Failure))
 
 dat :: [[Double]]
-dat = [ [66.22192174833207,   50.85424119528999]
+dat = [ [0.0,                 23.81232131645]
+      , [83.87632543135,      0.0]
+      , [0.0,                 0.0]
+      , [66.22192174833207,   50.85424119528999]
       , [18.507408294149144,  29.94826136042779]
       , [271.34564215397256,  482.0060747629345]
       , [0.33308595521927825, 0.25399999403605966]
@@ -82,7 +85,7 @@ chart = layoutToRenderable layout
       $ plot_bars_label_style . font_slant .~ FontSlantItalic
       $ def
 
-  dat' = map (\[a,b] -> [ (LogValue (min a b), "")
+  dat' = map (\[a,b] -> [ (LogValue (min a b), if a == b then "0.0" else "")
                         , if a < b then
                                      let v = b - a in
                                      (LogValue v, printf "%0.2f" v)
@@ -93,5 +96,7 @@ chart = layoutToRenderable layout
                                    else (LogValue 0, "")
                         ]) dat
 
-  alabels = map (\n -> "longDataPointName" ++ show n) $ take (length dat) [1..]
+  alabels =
+    ["addedDataPointName", "removedDataPointName", "nullDataPointName"] ++
+    map (\n -> "longDataPointName" ++ show n) (take (length dat - 3) [1..])
 


### PR DESCRIPTION
As a follow-up to #253, this fixes a problem with rendering log-axis stacked bars when bottom bars have value `0`, and updates the new test case correspondingly:

Cairo+PNG
![test20](https://github.com/timbod7/haskell-chart/assets/321557/35c06447-4977-4f75-ae94-7ed523174649)

Diagrams+SVG
![test20](https://github.com/timbod7/haskell-chart/assets/321557/34405f60-9f0a-4ff9-9e11-bee66f94786c)
